### PR TITLE
Adds private registration with config defined invite code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ APP_DEBUG=true
 APP_LOG_LEVEL=debug
 APP_URL=http://localhost
 
+INVITE_CODE="Fzd8BMfdR86NEuff"
+
 DB_CONNECTION=mysql
 DB_HOST=127.0.0.1
 DB_PORT=3306

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -27,7 +27,7 @@ class RegisterController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/login';
+    protected $redirectTo = '/';
 
     /**
      * Create a new controller instance.
@@ -36,7 +36,7 @@ class RegisterController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth');
+        $this->middleware('guest');
     }
 
     /**
@@ -51,6 +51,7 @@ class RegisterController extends Controller
             'name' => 'required|string|max:255',
             'email' => 'required|string|email|max:255|unique:users',
             'password' => 'required|string|min:6|confirmed',
+            'invite_code' => 'required|in:' . config('auth.invite_code')
         ]);
     }
 

--- a/config/auth.php
+++ b/config/auth.php
@@ -99,4 +99,15 @@ return [
         ],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Registration Invite Code
+    |--------------------------------------------------------------------------
+    |
+    | An account may only be registered if the invite code is provided.
+    |
+    */
+    'invite_code' => env('INVITE_CODE')
+
+
 ];

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -10,6 +10,20 @@
                     <form class="form-horizontal" method="POST" action="{{ route('register') }}">
                         {{ csrf_field() }}
 
+                        <div class="form-group{{ $errors->has('invite_code') ? ' has-error' : '' }}">
+                            <label for="name" class="col-md-4 control-label">Inbjudningskod</label>
+
+                            <div class="col-md-6">
+                                <input id="invite_code" type="text" class="form-control" name="invite_code" value="{{ old('invite_code', request()->input('invite_code')) }}" required>
+
+                                @if ($errors->has('invite_code'))
+                                    <span class="help-block">
+                                        <strong>{{ $errors->first('invite_code') }}</strong>
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
                         <div class="form-group{{ $errors->has('name') ? ' has-error' : '' }}">
                             <label for="name" class="col-md-4 control-label">Namn</label>
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -51,7 +51,7 @@
                                 </a>
 
                                 <ul class="dropdown-menu" role="menu">
-                                    <li><a href="{{ route('register') }}">Registrera ny användare</a></li>
+                                    <li><a href="#" onclick="javascript:prompt('Bjud in ny användare', '{{ route('register', ['invite_code' => config('auth.invite_code')]) }}');">Bjud in ny användare</a></li>
                                     <li>
                                         <a href="{{ route('logout') }}"
                                             onclick="event.preventDefault();


### PR DESCRIPTION
- The invite code is defined in .env, as `INVITE_CODE`
- Registration will fail without correct invite code
- Invite code can be passed in the URL or entered manually into the registration form
- An “invite new user” prompt will display the registration link (with invite code included) in the account dropdown
- Phrases have been translated to Swedish (invite code, invite new user)

Closes #9

